### PR TITLE
ENH: add an enum for substitution models

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,5 @@
 {
     "name": "piqtree2 devcontainer",
-    "context": "..",
     "image": "ghcr.io/cogent3/piqtree2:latest",
     "customizations": {
         "vscode": {
@@ -24,7 +23,8 @@
                 "github.vscode-github-actions",
                 "tamasfe.even-better-toml",
                 "DavidAnson.vscode-markdownlint",
-                "be5invis.toml"
+                "be5invis.toml",
+                "mhutchie.git-graph"
             ]
         }
     },
@@ -33,5 +33,5 @@
         "source=${localEnv:HOME}/.ssh,target=/home/user/.ssh,type=bind,consistency=cached",
         "source=${localEnv:USERPROFILE}/.ssh,target=/home/user/.ssh,type=bind,consistency=cached"
     ],
-    "postCreateCommand": "sudo chown -R user:user /home/user/.ssh"
+    "postCreateCommand": "sudo chown -R user:user /home/user/.ssh && git config --global --add safe.directory ${containerWorkspaceFolder}"
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -108,7 +108,8 @@ dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
     "INP001", # __init__.py files are not required...
     "ANN",
     "N802",
-    "N803"
+    "N803",
+    "SLF001"
 ]
 "noxfile.py" = [
     "S101", # asserts allowed in tests...

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,6 +117,7 @@ dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
     "N802",
     "N803"
 ]
+"src/piqtree2/model/_model.py" = ["N815"] # use IQ-TREE naming scheme
 
 [tool.ruff.format]
 # Like Black, use double quotes for strings.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,14 +109,16 @@ dummy-variable-rgx = "^(_+|(_+[a-zA-Z0-9_]*[a-zA-Z0-9]+?))$"
     "ANN",
     "N802",
     "N803",
-    "SLF001"
+    "SLF001",
+    "D"
 ]
 "noxfile.py" = [
     "S101", # asserts allowed in tests...
     "INP001", # __init__.py files are not required...
     "ANN",
     "N802",
-    "N803"
+    "N803",
+    "D"
 ]
 "src/piqtree2/model/_model.py" = ["N815"] # use IQ-TREE naming scheme
 

--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,5 @@
+"""setup for piqtree2."""
+
 from pybind11.setup_helpers import Pybind11Extension, build_ext
 from setuptools import setup
 

--- a/src/piqtree2/iqtree/__init__.py
+++ b/src/piqtree2/iqtree/__init__.py
@@ -1,3 +1,5 @@
+"""Functions for calling IQ-TREE as a library."""
+
 from ._random_tree import TreeGenMode, random_trees
 from ._robinson_foulds import robinson_foulds
 from ._tree import build_tree, fit_tree

--- a/src/piqtree2/model/__init__.py
+++ b/src/piqtree2/model/__init__.py
@@ -1,3 +1,4 @@
+from ._model import AaModel, DnaModel, Model
 from ._options import available_models
 
-__all__ = ["available_models"]
+__all__ = ["available_models", "AaModel", "DnaModel", "Model"]

--- a/src/piqtree2/model/__init__.py
+++ b/src/piqtree2/model/__init__.py
@@ -1,3 +1,5 @@
+"""Models available in IQ-TREE."""
+
 from ._model import AaModel, DnaModel, Model
 from ._options import available_models
 

--- a/src/piqtree2/model/_model.py
+++ b/src/piqtree2/model/_model.py
@@ -1,15 +1,22 @@
+import functools
+from abc import abstractmethod
 from enum import Enum, auto
-from typing import ClassVar
 
 from typing_extensions import Self
 
 
 class Model(Enum):
-    _descriptions: ClassVar[dict[Self, str]] = {}
+    @staticmethod
+    @abstractmethod
+    def model_type() -> str: ...
+
+    @staticmethod
+    @abstractmethod
+    def _descriptions() -> dict[Self, str]: ...
 
     @property
     def description(self) -> str:
-        return self._descriptions[self]
+        return self._descriptions()[self]
 
 
 class DnaModel(Model):
@@ -36,30 +43,37 @@ class DnaModel(Model):
     SYM = auto()
     GTR = auto()
 
-    _descriptions: ClassVar[dict[Self, str]] = {
-        JC: "Equal substitution rates and equal base frequencies (Jukes and Cantor, 1969).",
-        F81: "Equal rates but unequal base freq. (Felsenstein, 1981).",
-        K80: "Unequal transition/transversion rates and equal base freq. (Kimura, 1980).",
-        HKY: "Unequal transition/transversion rates and unequal base freq. (Hasegawa, Kishino and Yano, 1985).",
-        TN: "Like HKY but unequal purine/pyrimidine rates (Tamura and Nei, 1993).",
-        TNe: "Like TN but equal base freq.",
-        K81: "Three substitution types model and equal base freq. (Kimura, 1981).",
-        K81u: "Like K81 but unequal base freq.",
-        TPM2: "AC=AT, AG=CT, CG=GT and equal base freq.",
-        TPM2u: "Like TPM2 but unequal base freq.",
-        TPM3: "AC=CG, AG=CT, AT=GT and equal base freq.",
-        TPM3u: "Like TPM3 but unequal base freq.",
-        TIM: "Transition model, AC=GT, AT=CG and unequal base freq.",
-        TIMe: "Like TIM but equal base freq.",
-        TIM2: "AC=AT, CG=GT and unequal base freq.",
-        TIM2e: "Like TIM2 but equal base freq.",
-        TIM3: "AC=CG, AT=GT and unequal base freq.",
-        TIM3e: "Like TIM3 but equal base freq.",
-        TVM: "Transversion model, AG=CT and unequal base freq.",
-        TVMe: "Like TVM but equal base freq.",
-        SYM: "Symmetric model with unequal rates but equal base freq. (Zharkikh, 1994).",
-        GTR: "General time reversible model with unequal rates and unequal base freq. (Tavare, 1986).",
-    }
+    @staticmethod
+    def model_type() -> str:
+        return "nucleotide"
+
+    @staticmethod
+    @functools.cache
+    def _descriptions() -> dict[Self, str]:
+        return {
+            DnaModel.JC: "Equal substitution rates and equal base frequencies (Jukes and Cantor, 1969).",
+            DnaModel.F81: "Equal rates but unequal base freq. (Felsenstein, 1981).",
+            DnaModel.K80: "Unequal transition/transversion rates and equal base freq. (Kimura, 1980).",
+            DnaModel.HKY: "Unequal transition/transversion rates and unequal base freq. (Hasegawa, Kishino and Yano, 1985).",
+            DnaModel.TN: "Like HKY but unequal purine/pyrimidine rates (Tamura and Nei, 1993).",
+            DnaModel.TNe: "Like TN but equal base freq.",
+            DnaModel.K81: "Three substitution types model and equal base freq. (Kimura, 1981).",
+            DnaModel.K81u: "Like K81 but unequal base freq.",
+            DnaModel.TPM2: "AC=AT, AG=CT, CG=GT and equal base freq.",
+            DnaModel.TPM2u: "Like TPM2 but unequal base freq.",
+            DnaModel.TPM3: "AC=CG, AG=CT, AT=GT and equal base freq.",
+            DnaModel.TPM3u: "Like TPM3 but unequal base freq.",
+            DnaModel.TIM: "Transition model, AC=GT, AT=CG and unequal base freq.",
+            DnaModel.TIMe: "Like TIM but equal base freq.",
+            DnaModel.TIM2: "AC=AT, CG=GT and unequal base freq.",
+            DnaModel.TIM2e: "Like TIM2 but equal base freq.",
+            DnaModel.TIM3: "AC=CG, AT=GT and unequal base freq.",
+            DnaModel.TIM3e: "Like TIM3 but equal base freq.",
+            DnaModel.TVM: "Transversion model, AG=CT and unequal base freq.",
+            DnaModel.TVMe: "Like TVM but equal base freq.",
+            DnaModel.SYM: "Symmetric model with unequal rates but equal base freq. (Zharkikh, 1994).",
+            DnaModel.GTR: "General time reversible model with unequal rates and unequal base freq. (Tavare, 1986).",
+        }
 
 
 class AaModel(Model):
@@ -102,43 +116,53 @@ class AaModel(Model):
     VT = auto()
     WAG = auto()
 
-    _descriptions: ClassVar[dict[Self, str]] = {
-        Blosum62: "BLOcks SUbstitution Matrix (Henikoff and Henikoff, 1992). Note that BLOSUM62 is not recommended for phylogenetic analysis as it was designed mainly for sequence alignments.",
-        cpREV: "chloroplast matrix (Adachi et al., 2000).",
-        Dayhoff: "General matrix (Dayhoff et al., 1978).",
-        DCMut: "Revised Dayhoff matrix (Kosiol and Goldman, 2005).",
-        EAL: "General matrix. To be used with profile mixture models (for eg. EAL+C60) for reconstructing relationships between eukaryotes and Archaea (Banos et al., 2024).",
-        ELM: "General matrix. To be used with profile mixture models (for eg. ELM+C60) for phylogenetic analysis of proteins encoded by nuclear genomes of eukaryotes (Banos et al., 2024).",
-        FLAVI: "Flavivirus (Le and Vinh, 2020).",
-        FLU: "Influenza virus (Dang et al., 2010).",
-        GTR20: "General time reversible models with 190 rate parameters.",
-        HIVb: "HIV between-patient matrix HIV-Bm (Nickle et al., 2007).",
-        HIVw: "HIV within-patient matrix HIV-Wm (Nickle et al., 2007).",
-        JTT: "General matrix (Jones et al., 1992).",
-        JTTDCMut: "Revised JTT matrix (Kosiol and Goldman, 2005).",
-        LG: "General matrix (Le and Gascuel, 2008).",
-        mtART: "Mitochondrial Arthropoda (Abascal et al., 2007).",
-        mtMAM: "Mitochondrial Mammalia (Yang et al., 1998).",
-        mtREV: "Mitochondrial Vertebrate (Adachi and Hasegawa, 1996).",
-        mtZOA: "Mitochondrial Metazoa (Animals) (Rota-Stabelli et al., 2009).",
-        mtMet: "Mitochondrial Metazoa (Vinh et al., 2017).",
-        mtVer: "Mitochondrial Vertebrate (Vinh et al., 2017).",
-        mtInv: "Mitochondrial Inverterbrate (Vinh et al., 2017).",
-        NQ_bird: "Non-reversible Q matrix (Dang et al., 2022) estimated for birds (Jarvis et al., 2015).",
-        NQ_insect: "Non-reversible Q matrix (Dang et al., 2022) estimated for insects (Misof et al., 2014).",
-        NQ_mammal: "Non-reversible Q matrix (Dang et al., 2022) estimated for mammals (Wu et al., 2018).",
-        NQ_pfam: "General non-reversible Q matrix (Dang et al., 2022) estimated from Pfam version 31 database (El-Gebali et al., 2018).",
-        NQ_plant: "Non-reversible Q matrix (Dang et al., 2022) estimated for plants (Ran et al., 2018).",
-        NQ_yeast: "Non-reversible Q matrix (Dang et al., 2022) estimated for yeasts (Shen et al., 2018).",
-        Poisson: "Equal amino-acid exchange rates and frequencies.",
-        PMB: "Probability Matrix from Blocks, revised BLOSUM matrix (Veerassamy et al., 2004).",
-        Q_bird: "Q matrix (Minh et al., 2021) estimated for birds (Jarvis et al., 2015).",
-        Q_insect: "Q matrix (Minh et al., 2021) estimated for insects (Misof et al., 2014).",
-        Q_mammal: "Q matrix (Minh et al., 2021) estimated for mammals (Wu et al., 2018).",
-        Q_pfam: "General Q matrix (Minh et al., 2021) estimated from Pfam version 31 database (El-Gebali et al., 2018).",
-        Q_plant: "Q matrix (Minh et al., 2021) estimated for plants (Ran et al., 2018).",
-        Q_yeast: "Q matrix (Minh et al., 2021) estimated for yeasts (Shen et al., 2018).",
-        rtREV: "Retrovirus (Dimmic et al., 2002).",
-        VT: "General 'Variable Time' matrix (Mueller and Vingron, 2000).",
-        WAG: "General matrix (Whelan and Goldman, 2001).",
-    }
+    @staticmethod
+    def model_type() -> str:
+        return "protein"
+
+    @staticmethod
+    @functools.cache
+    def _descriptions() -> dict[Self, str]:
+        return {
+            AaModel.Blosum62: "BLOcks SUbstitution Matrix (Henikoff and Henikoff, 1992). Note that BLOSUM62 is not recommended for phylogenetic analysis as it was designed mainly for sequence alignments.",
+            AaModel.cpREV: "chloroplast matrix (Adachi et al., 2000).",
+            AaModel.Dayhoff: "General matrix (Dayhoff et al., 1978).",
+            AaModel.DCMut: "Revised Dayhoff matrix (Kosiol and Goldman, 2005).",
+            AaModel.EAL: "General matrix. To be used with profile mixture models (for eg. EAL+C60) for reconstructing relationships between eukaryotes and Archaea (Banos et al., 2024).",
+            AaModel.ELM: "General matrix. To be used with profile mixture models (for eg. ELM+C60) for phylogenetic analysis of proteins encoded by nuclear genomes of eukaryotes (Banos et al., 2024).",
+            AaModel.FLAVI: "Flavivirus (Le and Vinh, 2020).",
+            AaModel.FLU: "Influenza virus (Dang et al., 2010).",
+            AaModel.GTR20: "General time reversible models with 190 rate parameters.",
+            AaModel.HIVb: "HIV between-patient matrix HIV-Bm (Nickle et al., 2007).",
+            AaModel.HIVw: "HIV within-patient matrix HIV-Wm (Nickle et al., 2007).",
+            AaModel.JTT: "General matrix (Jones et al., 1992).",
+            AaModel.JTTDCMut: "Revised JTT matrix (Kosiol and Goldman, 2005).",
+            AaModel.LG: "General matrix (Le and Gascuel, 2008).",
+            AaModel.mtART: "Mitochondrial Arthropoda (Abascal et al., 2007).",
+            AaModel.mtMAM: "Mitochondrial Mammalia (Yang et al., 1998).",
+            AaModel.mtREV: "Mitochondrial Vertebrate (Adachi and Hasegawa, 1996).",
+            AaModel.mtZOA: "Mitochondrial Metazoa (Animals) (Rota-Stabelli et al., 2009).",
+            AaModel.mtMet: "Mitochondrial Metazoa (Vinh et al., 2017).",
+            AaModel.mtVer: "Mitochondrial Vertebrate (Vinh et al., 2017).",
+            AaModel.mtInv: "Mitochondrial Inverterbrate (Vinh et al., 2017).",
+            AaModel.NQ_bird: "Non-reversible Q matrix (Dang et al., 2022) estimated for birds (Jarvis et al., 2015).",
+            AaModel.NQ_insect: "Non-reversible Q matrix (Dang et al., 2022) estimated for insects (Misof et al., 2014).",
+            AaModel.NQ_mammal: "Non-reversible Q matrix (Dang et al., 2022) estimated for mammals (Wu et al., 2018).",
+            AaModel.NQ_pfam: "General non-reversible Q matrix (Dang et al., 2022) estimated from Pfam version 31 database (El-Gebali et al., 2018).",
+            AaModel.NQ_plant: "Non-reversible Q matrix (Dang et al., 2022) estimated for plants (Ran et al., 2018).",
+            AaModel.NQ_yeast: "Non-reversible Q matrix (Dang et al., 2022) estimated for yeasts (Shen et al., 2018).",
+            AaModel.Poisson: "Equal amino-acid exchange rates and frequencies.",
+            AaModel.PMB: "Probability Matrix from Blocks, revised BLOSUM matrix (Veerassamy et al., 2004).",
+            AaModel.Q_bird: "Q matrix (Minh et al., 2021) estimated for birds (Jarvis et al., 2015).",
+            AaModel.Q_insect: "Q matrix (Minh et al., 2021) estimated for insects (Misof et al., 2014).",
+            AaModel.Q_mammal: "Q matrix (Minh et al., 2021) estimated for mammals (Wu et al., 2018).",
+            AaModel.Q_pfam: "General Q matrix (Minh et al., 2021) estimated from Pfam version 31 database (El-Gebali et al., 2018).",
+            AaModel.Q_plant: "Q matrix (Minh et al., 2021) estimated for plants (Ran et al., 2018).",
+            AaModel.Q_yeast: "Q matrix (Minh et al., 2021) estimated for yeasts (Shen et al., 2018).",
+            AaModel.rtREV: "Retrovirus (Dimmic et al., 2002).",
+            AaModel.VT: "General 'Variable Time' matrix (Mueller and Vingron, 2000).",
+            AaModel.WAG: "General matrix (Whelan and Goldman, 2001).",
+        }
+
+
+ALL_MODELS_CLASSES: list[type[Model]] = [DnaModel, AaModel]

--- a/src/piqtree2/model/_model.py
+++ b/src/piqtree2/model/_model.py
@@ -6,20 +6,48 @@ from typing_extensions import Self
 
 
 class Model(Enum):
-    @staticmethod
-    @abstractmethod
-    def model_type() -> str: ...
+    """Base class for models."""
 
     @staticmethod
     @abstractmethod
-    def _descriptions() -> dict[Self, str]: ...
+    def model_type() -> str:
+        """Get the type of the model.
+
+        Returns
+        -------
+        str
+            The type of the model.
+
+        """
+
+    @staticmethod
+    @abstractmethod
+    def _descriptions() -> dict[Self, str]:
+        """Get the description of each model.
+
+        Returns
+        -------
+        dict[Self, str]
+            A mapping of models to their description.
+
+        """
 
     @property
     def description(self) -> str:
+        """The model's description.
+
+        Returns
+        -------
+        str
+            The model's description.
+
+        """
         return self._descriptions()[self]
 
 
 class DnaModel(Model):
+    """DNA substitution models."""
+
     JC = auto()
     F81 = auto()
     K80 = auto()
@@ -77,6 +105,8 @@ class DnaModel(Model):
 
 
 class AaModel(Model):
+    """Protein substitution models."""
+
     Blosum62 = auto()
     cpREV = auto()
     Dayhoff = auto()

--- a/src/piqtree2/model/_model.py
+++ b/src/piqtree2/model/_model.py
@@ -1,0 +1,144 @@
+from enum import Enum, auto
+from typing import ClassVar
+
+from typing_extensions import Self
+
+
+class Model(Enum):
+    _descriptions: ClassVar[dict[Self, str]] = {}
+
+    @property
+    def description(self) -> str:
+        return self._descriptions[self]
+
+
+class DnaModel(Model):
+    JC = auto()
+    F81 = auto()
+    K80 = auto()
+    HKY = auto()
+    TN = auto()
+    TNe = auto()
+    K81 = auto()
+    K81u = auto()
+    TPM2 = auto()
+    TPM2u = auto()
+    TPM3 = auto()
+    TPM3u = auto()
+    TIM = auto()
+    TIMe = auto()
+    TIM2 = auto()
+    TIM2e = auto()
+    TIM3 = auto()
+    TIM3e = auto()
+    TVM = auto()
+    TVMe = auto()
+    SYM = auto()
+    GTR = auto()
+
+    _descriptions: ClassVar[dict[Self, str]] = {
+        JC: "Equal substitution rates and equal base frequencies (Jukes and Cantor, 1969).",
+        F81: "Equal rates but unequal base freq. (Felsenstein, 1981).",
+        K80: "Unequal transition/transversion rates and equal base freq. (Kimura, 1980).",
+        HKY: "Unequal transition/transversion rates and unequal base freq. (Hasegawa, Kishino and Yano, 1985).",
+        TN: "Like HKY but unequal purine/pyrimidine rates (Tamura and Nei, 1993).",
+        TNe: "Like TN but equal base freq.",
+        K81: "Three substitution types model and equal base freq. (Kimura, 1981).",
+        K81u: "Like K81 but unequal base freq.",
+        TPM2: "AC=AT, AG=CT, CG=GT and equal base freq.",
+        TPM2u: "Like TPM2 but unequal base freq.",
+        TPM3: "AC=CG, AG=CT, AT=GT and equal base freq.",
+        TPM3u: "Like TPM3 but unequal base freq.",
+        TIM: "Transition model, AC=GT, AT=CG and unequal base freq.",
+        TIMe: "Like TIM but equal base freq.",
+        TIM2: "AC=AT, CG=GT and unequal base freq.",
+        TIM2e: "Like TIM2 but equal base freq.",
+        TIM3: "AC=CG, AT=GT and unequal base freq.",
+        TIM3e: "Like TIM3 but equal base freq.",
+        TVM: "Transversion model, AG=CT and unequal base freq.",
+        TVMe: "Like TVM but equal base freq.",
+        SYM: "Symmetric model with unequal rates but equal base freq. (Zharkikh, 1994).",
+        GTR: "General time reversible model with unequal rates and unequal base freq. (Tavare, 1986).",
+    }
+
+
+class AaModel(Model):
+    Blosum62 = auto()
+    cpREV = auto()
+    Dayhoff = auto()
+    DCMut = auto()
+    EAL = auto()
+    ELM = auto()
+    FLAVI = auto()
+    FLU = auto()
+    GTR20 = auto()
+    HIVb = auto()
+    HIVw = auto()
+    JTT = auto()
+    JTTDCMut = auto()
+    LG = auto()
+    mtART = auto()
+    mtMAM = auto()
+    mtREV = auto()
+    mtZOA = auto()
+    mtMet = auto()
+    mtVer = auto()
+    mtInv = auto()
+    NQ_bird = auto()
+    NQ_insect = auto()
+    NQ_mammal = auto()
+    NQ_pfam = auto()
+    NQ_plant = auto()
+    NQ_yeast = auto()
+    Poisson = auto()
+    PMB = auto()
+    Q_bird = auto()
+    Q_insect = auto()
+    Q_mammal = auto()
+    Q_pfam = auto()
+    Q_plant = auto()
+    Q_yeast = auto()
+    rtREV = auto()
+    VT = auto()
+    WAG = auto()
+
+    _descriptions: ClassVar[dict[Self, str]] = {
+        Blosum62: "BLOcks SUbstitution Matrix (Henikoff and Henikoff, 1992). Note that BLOSUM62 is not recommended for phylogenetic analysis as it was designed mainly for sequence alignments.",
+        cpREV: "chloroplast matrix (Adachi et al., 2000).",
+        Dayhoff: "General matrix (Dayhoff et al., 1978).",
+        DCMut: "Revised Dayhoff matrix (Kosiol and Goldman, 2005).",
+        EAL: "General matrix. To be used with profile mixture models (for eg. EAL+C60) for reconstructing relationships between eukaryotes and Archaea (Banos et al., 2024).",
+        ELM: "General matrix. To be used with profile mixture models (for eg. ELM+C60) for phylogenetic analysis of proteins encoded by nuclear genomes of eukaryotes (Banos et al., 2024).",
+        FLAVI: "Flavivirus (Le and Vinh, 2020).",
+        FLU: "Influenza virus (Dang et al., 2010).",
+        GTR20: "General time reversible models with 190 rate parameters.",
+        HIVb: "HIV between-patient matrix HIV-Bm (Nickle et al., 2007).",
+        HIVw: "HIV within-patient matrix HIV-Wm (Nickle et al., 2007).",
+        JTT: "General matrix (Jones et al., 1992).",
+        JTTDCMut: "Revised JTT matrix (Kosiol and Goldman, 2005).",
+        LG: "General matrix (Le and Gascuel, 2008).",
+        mtART: "Mitochondrial Arthropoda (Abascal et al., 2007).",
+        mtMAM: "Mitochondrial Mammalia (Yang et al., 1998).",
+        mtREV: "Mitochondrial Vertebrate (Adachi and Hasegawa, 1996).",
+        mtZOA: "Mitochondrial Metazoa (Animals) (Rota-Stabelli et al., 2009).",
+        mtMet: "Mitochondrial Metazoa (Vinh et al., 2017).",
+        mtVer: "Mitochondrial Vertebrate (Vinh et al., 2017).",
+        mtInv: "Mitochondrial Inverterbrate (Vinh et al., 2017).",
+        NQ_bird: "Non-reversible Q matrix (Dang et al., 2022) estimated for birds (Jarvis et al., 2015).",
+        NQ_insect: "Non-reversible Q matrix (Dang et al., 2022) estimated for insects (Misof et al., 2014).",
+        NQ_mammal: "Non-reversible Q matrix (Dang et al., 2022) estimated for mammals (Wu et al., 2018).",
+        NQ_pfam: "General non-reversible Q matrix (Dang et al., 2022) estimated from Pfam version 31 database (El-Gebali et al., 2018).",
+        NQ_plant: "Non-reversible Q matrix (Dang et al., 2022) estimated for plants (Ran et al., 2018).",
+        NQ_yeast: "Non-reversible Q matrix (Dang et al., 2022) estimated for yeasts (Shen et al., 2018).",
+        Poisson: "Equal amino-acid exchange rates and frequencies.",
+        PMB: "Probability Matrix from Blocks, revised BLOSUM matrix (Veerassamy et al., 2004).",
+        Q_bird: "Q matrix (Minh et al., 2021) estimated for birds (Jarvis et al., 2015).",
+        Q_insect: "Q matrix (Minh et al., 2021) estimated for insects (Misof et al., 2014).",
+        Q_mammal: "Q matrix (Minh et al., 2021) estimated for mammals (Wu et al., 2018).",
+        Q_pfam: "General Q matrix (Minh et al., 2021) estimated from Pfam version 31 database (El-Gebali et al., 2018).",
+        Q_plant: "Q matrix (Minh et al., 2021) estimated for plants (Ran et al., 2018).",
+        Q_yeast: "Q matrix (Minh et al., 2021) estimated for yeasts (Shen et al., 2018).",
+        rtREV: "Retrovirus (Dimmic et al., 2002).",
+        VT: "General 'Variable Time' matrix (Mueller and Vingron, 2000).",
+        WAG: "General matrix (Whelan and Goldman, 2001).",
+    }

--- a/src/piqtree2/model/_options.py
+++ b/src/piqtree2/model/_options.py
@@ -5,6 +5,8 @@ from typing import Optional
 
 from cogent3 import _Table, make_table
 
+from piqtree2.model._model import ALL_MODELS_CLASSES, AaModel, DnaModel, Model
+
 _dna_models = {
     "Abbreviation": [
         "JC",
@@ -140,14 +142,18 @@ _aa_models = {
 
 
 @functools.cache
-def _make_all_models() -> dict[str, list[str]]:
-    _all_models = {"Model Type": [], "Abbreviation": [], "Description": []}
-    for model_type, models in zip(["nucleotide", "protein"], [_dna_models, _aa_models]):
-        mtype = [model_type] * len(models["Abbreviation"])
-        _all_models["Model Type"].extend(mtype)
-        _all_models["Abbreviation"].extend(models["Abbreviation"])
-        _all_models["Description"].extend(models["Description"])
-    return _all_models
+def _make_models(model_type: type[Model]) -> dict[str, list[str]]:
+    data = {"Model Type": [], "Abbreviation": [], "Description": []}
+
+    model_classes = ALL_MODELS_CLASSES if model_type == Model else [model_type]
+
+    for model_class in model_classes:
+        for model in model_class:
+            data["Model Type"].append(model.model_type())
+            data["Abbreviation"].append(model.name)
+            data["Description"].append(model.description)
+
+    return data
 
 
 def available_models(model_type: Optional[str] = None) -> _Table:
@@ -160,10 +166,10 @@ def available_models(model_type: Optional[str] = None) -> _Table:
 
     """
     if model_type == "dna":
-        table = make_table(data=_dna_models)
+        table = make_table(data=_make_models(DnaModel))
     elif model_type == "protein":
-        table = make_table(data=_aa_models)
+        table = make_table(data=_make_models(AaModel))
     else:
-        table = make_table(data=_make_all_models())
+        table = make_table(data=_make_models(Model))
 
     return table

--- a/tests/test_model/test_model.py
+++ b/tests/test_model/test_model.py
@@ -1,0 +1,25 @@
+import pytest
+from piqtree2.model import AaModel, DnaModel
+
+
+@pytest.mark.parametrize("model_class", [DnaModel, AaModel])
+def test_number_of_descriptions(model_class):
+    assert len(model_class) == len(model_class._descriptions())
+
+
+@pytest.mark.parametrize("model_class", [DnaModel, AaModel])
+def test_descriptions_exist(model_class):
+    for model in model_class:
+        # Raises an error if description not present
+        _ = model.description
+
+
+@pytest.mark.parametrize(
+    ("model_class", "model_type"),
+    [(DnaModel, "nucleotide"), (AaModel, "protein")],
+)
+def test_model_type(model_class, model_type):
+    assert model_class.model_type() == model_type
+
+    for model in model_class:
+        assert model.model_type() == model_type

--- a/tests/test_model/test_options.py
+++ b/tests/test_model/test_options.py
@@ -1,9 +1,32 @@
 # testing the display of functions
 import pytest
 from piqtree2 import available_models
+from piqtree2.model import AaModel, DnaModel
 
 
-@pytest.mark.parametrize("model_type", [None, "dna", "protein"])
-def test_available_models(model_type):
+@pytest.mark.parametrize(
+    ("model_class", "model_type"),
+    [(None, None), (DnaModel, "dna"), (AaModel, "protein")],
+)
+def test_num_available_models(model_class, model_type):
     table = available_models(model_type)
-    assert table.shape[0] > 0
+    total_models = (
+        len(DnaModel) + len(AaModel) if model_class is None else len(model_class)
+    )
+    assert total_models > 0
+    assert table.shape[0] == total_models
+
+
+@pytest.mark.parametrize(
+    ("model_fetch", "model_type"),
+    [(None, None), ("dna", "nucleotide"), ("protein", "protein")],
+)
+def test_available_models_types(model_fetch, model_type):
+    table = available_models(model_fetch)
+
+    if model_type is None:
+        for check_model_type in table[:, 0]:
+            assert check_model_type[0] in ["nucleotide", "protein"]
+    else:
+        for check_model_type in table[:, 0]:
+            assert check_model_type[0] == model_type


### PR DESCRIPTION
An implementation of #17. Model names are stored in the same region as their descriptions. Tests ensure every model must have a matching description to go with it.

Options now fetches the relevant data from the enums to generate tables for `available_models()`

Models are names matching IQ-TREE's side of things. Any periods in the model names have been replaced by underscores (12 protein models effected - used to be `Q.`, now `Q_`).

Before hooking this in to `fit_tree` and `build_tree`, as there are a couple of ways to go about this, I wanted to check this scheme. Let me know if you'd like any changes to the naming scheme/class setup.