### PR TITLE
TST: added tests for branch lengths 

### DIFF
--- a/tests/test_iqtree/test_build_tree.py
+++ b/tests/test_iqtree/test_build_tree.py
@@ -15,18 +15,33 @@ from piqtree2.model import (
 )
 
 
-def init_model(
+def check_build_tree(
+    four_otu: ArrayAlignment,
     dna_model: DnaModel,
     freq_type: Optional[FreqType] = None,
     invariable_sites: Optional[bool] = None,
     rate_model: Optional[RateModel] = None,
-) -> Model:
+) -> None:
+    expected = make_tree("(Human,Chimpanzee,(Rhesus,Mouse));")
 
-    return Model(
+    model = Model(
         dna_model,
         freq_type,
         RateType(invariable_sites=invariable_sites, model=rate_model),
     )
+
+    got1 = piqtree2.build_tree(four_otu, model, rand_seed=1)
+    got1 = got1.unrooted()
+    # Check topology
+    assert expected.same_topology(got1.unrooted())
+    # Check if branch lengths exist
+    assert all("length" in v.params for v in got1.get_edge_vector())
+
+    # Should be similar for any seed
+    got2 = piqtree2.build_tree(four_otu, model, rand_seed=None)
+    got2 = got2.unrooted()
+    assert expected.same_topology(got2)
+    assert all("length" in v.params for v in got2.get_edge_vector())
 
 
 @pytest.mark.parametrize("dna_model", list(DnaModel)[:22])
@@ -36,40 +51,12 @@ def test_non_lie_build_tree(
     dna_model: DnaModel,
     freq_type: FreqType,
 ) -> None:
-    expected = make_tree("(Human,Chimpanzee,(Rhesus,Mouse));")
-    model = init_model(dna_model, freq_type)
-
-    got1 = piqtree2.build_tree(four_otu, model, rand_seed=1)
-    got1 = got1.unrooted()
-    # Check topology
-    assert expected.same_topology(got1.unrooted())
-    # Check if branch lengths exist
-    assert all("length" in v.params for v in got1.get_edge_vector())
-
-    # Should be similar for any seed
-    got2 = piqtree2.build_tree(four_otu, model, rand_seed=None)
-    got2 = got2.unrooted()
-    assert expected.same_topology(got2)
-    assert all("length" in v.params for v in got2.get_edge_vector())
+    check_build_tree(four_otu, dna_model, freq_type)
 
 
 @pytest.mark.parametrize("dna_model", list(DnaModel)[22:])
 def test_lie_build_tree(four_otu: ArrayAlignment, dna_model: DnaModel) -> None:
-    expected = make_tree("(Human,Chimpanzee,(Rhesus,Mouse));")
-    model = init_model(dna_model)
-
-    got1 = piqtree2.build_tree(four_otu, model, rand_seed=1)
-    got1 = got1.unrooted()
-    # Check topology
-    assert expected.same_topology(got1.unrooted())
-    # Check if branch lengths exist
-    assert all("length" in v.params for v in got1.get_edge_vector())
-
-    # Should be similar for any seed
-    got2 = piqtree2.build_tree(four_otu, model, rand_seed=None)
-    got2 = got2.unrooted()
-    assert expected.same_topology(got2)
-    assert all("length" in v.params for v in got2.get_edge_vector())
+    check_build_tree(four_otu, dna_model)
 
 
 @pytest.mark.parametrize("dna_model", list(DnaModel)[:5])
@@ -90,22 +77,9 @@ def test_rate_model_build_tree(
     invariable_sites: Optional[bool],
     rate_model: RateModel,
 ) -> None:
-    expected = make_tree("(Human,Chimpanzee,(Rhesus,Mouse));")
-    model = init_model(
+    check_build_tree(
+        four_otu,
         dna_model,
         invariable_sites=invariable_sites,
         rate_model=rate_model,
     )
-
-    got1 = piqtree2.build_tree(four_otu, model, rand_seed=1)
-    got1 = got1.unrooted()
-    # Check topology
-    assert expected.same_topology(got1.unrooted())
-    # Check if branch lengths exist
-    assert all("length" in v.params for v in got1.get_edge_vector())
-
-    # Should be similar for any seed
-    got2 = piqtree2.build_tree(four_otu, model, rand_seed=None)
-    got2 = got2.unrooted()
-    assert expected.same_topology(got2)
-    assert all("length" in v.params for v in got2.get_edge_vector())

--- a/tests/test_iqtree/test_build_tree.py
+++ b/tests/test_iqtree/test_build_tree.py
@@ -1,8 +1,9 @@
 from typing import Optional
 
-import piqtree2
 import pytest
 from cogent3 import ArrayAlignment, make_tree
+
+import piqtree2
 from piqtree2.model import (
     DiscreteGammaModel,
     DnaModel,
@@ -14,29 +15,18 @@ from piqtree2.model import (
 )
 
 
-def check_build_tree(
-    four_otu: ArrayAlignment,
+def init_model(
     dna_model: DnaModel,
     freq_type: Optional[FreqType] = None,
     invariable_sites: Optional[bool] = None,
     rate_model: Optional[RateModel] = None,
-) -> None:
-    expected = make_tree("(Human,Chimpanzee,(Rhesus,Mouse));")
+) -> Model:
 
-    model = Model(
+    return Model(
         dna_model,
         freq_type,
         RateType(invariable_sites=invariable_sites, model=rate_model),
     )
-
-    got1 = piqtree2.build_tree(four_otu, model, rand_seed=1)
-    got1 = got1.unrooted()
-    assert expected.same_topology(got1.unrooted())
-
-    # Should be similar for any seed
-    got2 = piqtree2.build_tree(four_otu, model, rand_seed=None)
-    got2 = got2.unrooted()
-    assert expected.same_topology(got2)
 
 
 @pytest.mark.parametrize("dna_model", list(DnaModel)[:22])
@@ -46,12 +36,40 @@ def test_non_lie_build_tree(
     dna_model: DnaModel,
     freq_type: FreqType,
 ) -> None:
-    check_build_tree(four_otu, dna_model, freq_type)
+    expected = make_tree("(Human,Chimpanzee,(Rhesus,Mouse));")
+    model = init_model(dna_model, freq_type)
+
+    got1 = piqtree2.build_tree(four_otu, model, rand_seed=1)
+    got1 = got1.unrooted()
+    # Check topology
+    assert expected.same_topology(got1.unrooted())
+    # Check if branch lengths exist
+    assert all("length" in v.params for v in got1.get_edge_vector())
+
+    # Should be similar for any seed
+    got2 = piqtree2.build_tree(four_otu, model, rand_seed=None)
+    got2 = got2.unrooted()
+    assert expected.same_topology(got2)
+    assert all("length" in v.params for v in got2.get_edge_vector())
 
 
 @pytest.mark.parametrize("dna_model", list(DnaModel)[22:])
 def test_lie_build_tree(four_otu: ArrayAlignment, dna_model: DnaModel) -> None:
-    check_build_tree(four_otu, dna_model)
+    expected = make_tree("(Human,Chimpanzee,(Rhesus,Mouse));")
+    model = init_model(dna_model)
+
+    got1 = piqtree2.build_tree(four_otu, model, rand_seed=1)
+    got1 = got1.unrooted()
+    # Check topology
+    assert expected.same_topology(got1.unrooted())
+    # Check if branch lengths exist
+    assert all("length" in v.params for v in got1.get_edge_vector())
+
+    # Should be similar for any seed
+    got2 = piqtree2.build_tree(four_otu, model, rand_seed=None)
+    got2 = got2.unrooted()
+    assert expected.same_topology(got2)
+    assert all("length" in v.params for v in got2.get_edge_vector())
 
 
 @pytest.mark.parametrize("dna_model", list(DnaModel)[:5])
@@ -72,9 +90,22 @@ def test_rate_model_build_tree(
     invariable_sites: Optional[bool],
     rate_model: RateModel,
 ) -> None:
-    check_build_tree(
-        four_otu,
+    expected = make_tree("(Human,Chimpanzee,(Rhesus,Mouse));")
+    model = init_model(
         dna_model,
         invariable_sites=invariable_sites,
         rate_model=rate_model,
     )
+
+    got1 = piqtree2.build_tree(four_otu, model, rand_seed=1)
+    got1 = got1.unrooted()
+    # Check topology
+    assert expected.same_topology(got1.unrooted())
+    # Check if branch lengths exist
+    assert all("length" in v.params for v in got1.get_edge_vector())
+
+    # Should be similar for any seed
+    got2 = piqtree2.build_tree(four_otu, model, rand_seed=None)
+    got2 = got2.unrooted()
+    assert expected.same_topology(got2)
+    assert all("length" in v.params for v in got2.get_edge_vector())

--- a/tests/test_iqtree/test_fit_tree.py
+++ b/tests/test_iqtree/test_fit_tree.py
@@ -1,8 +1,53 @@
-import piqtree2
 import pytest
 from cogent3 import ArrayAlignment, get_app, make_tree
+
+import piqtree2
 from piqtree2.model import DnaModel, Model
 
+
+def check_likelihood(got:float, expected:float) -> None:
+    assert got == pytest.approx(expected)
+
+def check_motif_probs(got:dict, expected:dict) -> None:
+    expected_keys = set(expected.keys())
+    got_keys = set(got.keys())
+    # Check that the base characters are the same
+    assert expected_keys == got_keys
+
+    # Check that the probs are the same
+    expected_values = [expected[key] for key in expected_keys]
+    got_values = [got[key] for key in expected_keys]
+    assert all(got == pytest.approx(exp) for got, exp in zip(got_values, expected_values))
+
+def check_rate_parameters(got:dict, expected:dict) -> None:
+    # Collect all rate parameters in got and expected
+    exclude = {"length", "ENS", "paralinear", "mprobs"}
+    expected_keys = {
+        k
+        for k in expected[0].params
+        if k not in exclude
+    }
+    got_keys = {k for k in got[0].params if k not in exclude}
+
+
+    # Check that the keys of rate are the same
+    assert expected_keys == got_keys
+
+    # Check that the values of rate are the same
+    expected_values = [expected[0].params[key] for key in expected_keys]
+    got_values = [got[0].params[key] for key in expected_keys]
+
+    assert all(got == pytest.approx(exp, rel=1e-2) for got, exp in zip(got_values, expected_values))
+
+def check_branch_lengths(got:dict, expected:dict) -> None:
+    # Check that the keys of branch lengths are the same
+    assert got.keys() == expected.keys()
+
+    # Check that the branch lengths are the same
+    expected_values = [expected[key] for key in expected]
+    got_values = [got[key] for key in expected]
+
+    assert all(got == pytest.approx(exp, rel=1e-2) for got, exp in zip(got_values, expected_values))
 
 @pytest.mark.parametrize(
     ("iq_model", "c3_model"),
@@ -21,27 +66,14 @@ def test_fit_tree(three_otu: ArrayAlignment, iq_model: DnaModel, c3_model: str) 
     expected = app(three_otu)
 
     got1 = piqtree2.fit_tree(three_otu, tree_topology, Model(iq_model), rand_seed=1)
-    assert got1.params["lnL"] == pytest.approx(expected.lnL)
+    check_likelihood(got1.params["lnL"], expected.lnL)
+    check_motif_probs(got1.params["mprobs"], expected.tree.params["mprobs"])
+    check_rate_parameters(got1.get_edge_vector(), expected.tree.get_edge_vector())
+    check_branch_lengths(got1.get_distances(), expected.tree.get_distances())
 
     # Should be within an approximation for any seed
     got2 = piqtree2.fit_tree(three_otu, tree_topology, Model(iq_model), rand_seed=None)
-    assert got2.params["lnL"] == pytest.approx(expected.lnL)
-
-    # Check motif and rate parameters
-    expected_motif_prob = expected.tree.params["mprobs"]
-    for k, v in expected_motif_prob.items():
-        assert k in got2.params["mprobs"]
-        assert got2.params["mprobs"][k] == pytest.approx(v)
-
-    exclude = {"length", "ENS", "paralinear", "mprobs"}
-    expected_rates = {
-        k: v
-        for k, v in expected.tree.get_edge_vector()[0].params.items()
-        if k not in exclude
-    }
-    for k, v in expected_rates.items():
-        assert k in got2.get_edge_vector()[0].params
-        assert got2.get_edge_vector()[0].params[k] == pytest.approx(
-            v,
-            rel=1e-2,
-        )
+    check_likelihood(got2.params["lnL"], expected.lnL)
+    check_motif_probs(got2.params["mprobs"], expected.tree.params["mprobs"])
+    check_rate_parameters(got2.get_edge_vector(), expected.tree.get_edge_vector())
+    check_branch_lengths(got2.get_distances(), expected.tree.get_distances())

--- a/tests/test_iqtree/test_fit_tree.py
+++ b/tests/test_iqtree/test_fit_tree.py
@@ -1,34 +1,41 @@
 import pytest
 from cogent3 import ArrayAlignment, get_app, make_tree
+from cogent3.app.result import model_result
+from cogent3.core.tree import PhyloNode
 
 import piqtree2
 from piqtree2.model import DnaModel, Model
 
 
-def check_likelihood(got:float, expected:float) -> None:
-    assert got == pytest.approx(expected)
+def check_likelihood(got: PhyloNode, expected: model_result) -> None:
+    assert got.params["lnL"] == pytest.approx(expected.lnL)
 
-def check_motif_probs(got:dict, expected:dict) -> None:
+
+def check_motif_probs(got: PhyloNode, expected: PhyloNode) -> None:
+    expected = expected.params["mprobs"]
+    got = got.params["mprobs"]
+
     expected_keys = set(expected.keys())
     got_keys = set(got.keys())
+
     # Check that the base characters are the same
     assert expected_keys == got_keys
 
     # Check that the probs are the same
     expected_values = [expected[key] for key in expected_keys]
     got_values = [got[key] for key in expected_keys]
-    assert all(got == pytest.approx(exp) for got, exp in zip(got_values, expected_values))
+    assert all(
+        got == pytest.approx(exp) for got, exp in zip(got_values, expected_values)
+    )
 
-def check_rate_parameters(got:dict, expected:dict) -> None:
+
+def check_rate_parameters(got: PhyloNode, expected: PhyloNode) -> None:
     # Collect all rate parameters in got and expected
     exclude = {"length", "ENS", "paralinear", "mprobs"}
     expected_keys = {
-        k
-        for k in expected[0].params
-        if k not in exclude
+        k for k in expected.get_edge_vector()[0].params if k not in exclude
     }
-    got_keys = {k for k in got[0].params if k not in exclude}
-
+    got_keys = {k for k in got.get_edge_vector()[0].params if k not in exclude}
 
     # Check that the keys of rate are the same
     assert expected_keys == got_keys
@@ -37,9 +44,15 @@ def check_rate_parameters(got:dict, expected:dict) -> None:
     expected_values = [expected[0].params[key] for key in expected_keys]
     got_values = [got[0].params[key] for key in expected_keys]
 
-    assert all(got == pytest.approx(exp, rel=1e-2) for got, exp in zip(got_values, expected_values))
+    assert all(
+        got == pytest.approx(exp, rel=1e-2)
+        for got, exp in zip(got_values, expected_values)
+    )
 
-def check_branch_lengths(got:dict, expected:dict) -> None:
+
+def check_branch_lengths(got: PhyloNode, expected: PhyloNode) -> None:
+    got = got.get_distances()
+    expected = expected.get_distances()
     # Check that the keys of branch lengths are the same
     assert got.keys() == expected.keys()
 
@@ -47,7 +60,11 @@ def check_branch_lengths(got:dict, expected:dict) -> None:
     expected_values = [expected[key] for key in expected]
     got_values = [got[key] for key in expected]
 
-    assert all(got == pytest.approx(exp, rel=1e-2) for got, exp in zip(got_values, expected_values))
+    assert all(
+        got == pytest.approx(exp, rel=1e-2)
+        for got, exp in zip(got_values, expected_values)
+    )
+
 
 @pytest.mark.parametrize(
     ("iq_model", "c3_model"),
@@ -66,14 +83,14 @@ def test_fit_tree(three_otu: ArrayAlignment, iq_model: DnaModel, c3_model: str) 
     expected = app(three_otu)
 
     got1 = piqtree2.fit_tree(three_otu, tree_topology, Model(iq_model), rand_seed=1)
-    check_likelihood(got1.params["lnL"], expected.lnL)
-    check_motif_probs(got1.params["mprobs"], expected.tree.params["mprobs"])
-    check_rate_parameters(got1.get_edge_vector(), expected.tree.get_edge_vector())
-    check_branch_lengths(got1.get_distances(), expected.tree.get_distances())
+    check_likelihood(got1, expected)
+    check_motif_probs(got1, expected.tree)
+    check_rate_parameters(got1, expected.tree)
+    check_branch_lengths(got1, expected.tree)
 
     # Should be within an approximation for any seed
     got2 = piqtree2.fit_tree(three_otu, tree_topology, Model(iq_model), rand_seed=None)
-    check_likelihood(got2.params["lnL"], expected.lnL)
-    check_motif_probs(got2.params["mprobs"], expected.tree.params["mprobs"])
-    check_rate_parameters(got2.get_edge_vector(), expected.tree.get_edge_vector())
-    check_branch_lengths(got2.get_distances(), expected.tree.get_distances())
+    check_likelihood(got2, expected)
+    check_motif_probs(got2, expected.tree)
+    check_rate_parameters(got2, expected.tree)
+    check_branch_lengths(got2, expected.tree)


### PR DESCRIPTION
#76
- added tests to check if branch lengths estimated from cogent3 and iqtree2 are within `rel=1e-2` for GTR, JC, F81, HKY, TN, K80, when calling `fit_tree`.
- added tests to check if branch lengths exist for all `DnaModel` when calling `build_tree`.